### PR TITLE
fix: remove stray branch markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,11 @@ This Fastify service receives Bubble user profile data, generates domain and tas
 
 ---
 
-codex/implement-user-capsule-upsert-service-1ryqf1
 
 ## Keeping your local branches in sync
 
 After merging a pull request, reset your local `main` branch to the latest GitHub state before starting new work. The step-by-step commands live in [`docs/git-workflow.md`](docs/git-workflow.md) and prevent Codex from reintroducing files that already exist on `main`.
 
-codex/implement-user-capsule-upsert-service-1ryqf1
 - **Quick option:** run `npm run sync:main` (optionally `npm run sync:main -- <feature-branch>`) to fetch from GitHub, reset `main` to `origin/main`, and—when provided—create a fresh feature branch in one command. The script refuses to run with uncommitted changes so you do not lose work by accident.
 
 ---
@@ -28,7 +26,6 @@ Copy `.env.example` to `.env` during local development and provide the following
 | `PINECONE_HOST` | ✅ | Serverless host URL for the index (e.g., `freelancers_v2-xxxxxx.svc.us-east1-aws.pinecone.io`). |
 | `PINECONE_ENV` | ➖ | Legacy controller host fallback. Only use if `PINECONE_HOST` is temporarily unavailable. |
 | `SERVICE_API_KEY` | ✅ | Bearer token Bubble must send with every request. |
-codex/implement-user-capsule-upsert-service-1ryqf1
 | `OPENAI_CAPSULE_MODEL` | ➖ | Optional chat model override for capsule generation. Defaults to `gpt-4o-mini` when unset. |
 
 | `LOG_LEVEL` | ➖ | Pino log level (`info` by default). |
@@ -72,7 +69,6 @@ During local runs the service logs request lifecycle events (start → capsules 
 
 1. Fork or clone this repository into your GitHub account.
 2. In Render, click **New + → Blueprint** and connect the GitHub repo. Render will detect `render.yaml`.
-codex/implement-user-capsule-upsert-service-1ryqf1
 3. Before clicking **Deploy**, open the service’s **Environment** tab in Render and add values for each required variable: `OPENAI_API_KEY`, `PINECONE_API_KEY`, `PINECONE_INDEX`, `PINECONE_HOST`, `SERVICE_API_KEY`, plus optional overrides such as `OPENAI_CAPSULE_MODEL`, `LOG_LEVEL`, and `PORT` (defaults to `8080`). The Blueprint already defines the keys so you only need to fill in the values. It also pins `NODE_VERSION=20.18.0` and `NPM_CONFIG_PRODUCTION=false` so builds run with a modern Node runtime while still installing dev dependencies (TypeScript). If you create the service manually, set both keys under **Environment** before the first deploy.
 4. After the environment variables are saved, trigger the deploy. Render will run `npm ci && npm run build` and start the app with `node dist/server.js` using Node 20.
 
@@ -82,7 +78,6 @@ codex/implement-user-capsule-upsert-service-1ryqf1
    curl https://<your-render-service>.onrender.com/health
    ```
 7. Test the upsert endpoint:
-codex/implement-user-capsule-upsert-service-1ryqf1
 
    ```bash
    curl -X POST "https://<your-render-service>.onrender.com/v1/users/upsert" \
@@ -124,7 +119,6 @@ Render’s logs will show the lifecycle events and you should receive `status: "
 ## OpenAI configuration
 
 - Set `OPENAI_API_KEY` in Render’s environment settings (or `.env` locally).
-codex/implement-user-capsule-upsert-service-1ryqf1
 - (Optional) Set `OPENAI_CAPSULE_MODEL` if you want the service to use a specific chat model for capsule generation (for example, `gpt-4o`). When unset, the service defaults to `gpt-4o-mini` and logs a warning on first use.
 
 - The service calls OpenAI Chat once per request (temperature `0.2`) and the embeddings API twice using `text-embedding-3-large` (dimension `3072`). Ensure your OpenAI account has quota for both.
@@ -185,7 +179,6 @@ A minimal collection is available at [`postman/collection.json`](postman/collect
 3. Endpoint: `POST /v1/users/upsert`.
 4. Payload fields:
    - `user_id` = Current User’s unique ID.
-codex/implement-user-capsule-upsert-service-1ryqf1
    - `resume_text` = Current User’s resume text (full text is accepted; no server-side character limit).
 
    - Optional arrays (`work_experience`, `education`, `labeling_experience`, `languages`) formatted as text lists.
@@ -197,7 +190,6 @@ codex/implement-user-capsule-upsert-service-1ryqf1
 
 > Do **not** store Pinecone vectors in Bubble—the service writes them directly to Pinecone.
 
-codex/implement-user-capsule-upsert-service-1ryqf1
 See [`docs/bubble-and-deployment.md`](docs/bubble-and-deployment.md) for the exact Bubble field names and the live Render service reference.
 
 

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -1,6 +1,5 @@
 # Git workflow after merging PRs
 
-codex/implement-user-capsule-upsert-service-1ryqf1
 Keeping Codex in sync with GitHub’s `main` branch prevents the “same files keep coming back” merge conflicts you were seeing. Follow the Codex steps before starting a new task and repeat the local routine if you also work from a personal machine.
 
 > **Shortcut:** Run `npm run sync:main` (or `npm run sync:main -- <feature-branch>`) inside the Codex terminal to fetch the latest commits, reset `main` to `origin/main`, and optionally create a fresh feature branch in one go. The script aborts if there are unstaged changes so you can stash or commit before syncing.
@@ -23,7 +22,6 @@ Completing this sync step before each task ensures every PR starts from the curr
 
 ## Local machine routine
 
-codex/implement-user-capsule-upsert-service-1ryqf1
 
 1. **Sync the local `main` branch**
    ```bash
@@ -52,7 +50,6 @@ codex/implement-user-capsule-upsert-service-1ryqf1
    ```
    If Codex creates the branch for you, double-check in the GitHub UI that it is based on the newest `main`.
 
-codex/implement-user-capsule-upsert-service-1ryqf1
 By repeating these routines you avoid add/add conflicts with files already merged into `main` and ensure follow-up PRs only contain new work.
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,12 +23,10 @@
         "tsx": "^4.20.5",
         "typescript": "^5.9.2",
         "vitest": "^3.2.4"
-codex/implement-user-capsule-upsert-service-1ryqf1
       },
       "engines": {
         "node": ">=20.18.0",
         "npm": ">=10.0.0"
-
       }
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "dev": "tsx watch src/server.ts",
     "test": "vitest run",
     "test:watch": "vitest",
-codex/implement-user-capsule-upsert-service-1ryqf1
     "index:create": "ts-node scripts/create-index.ts",
     "sync:main": "bash scripts/sync-main.sh"
 
@@ -21,7 +20,6 @@ codex/implement-user-capsule-upsert-service-1ryqf1
     "node": ">=20.18.0",
     "npm": ">=10.0.0"
   },
-codex/implement-user-capsule-upsert-service-1ryqf1
 
   "dependencies": {
     "@pinecone-database/pinecone": "^6.1.2",

--- a/render.yaml
+++ b/render.yaml
@@ -6,19 +6,16 @@ services:
     startCommand: node dist/server.js
     healthCheckPath: /health
     envVars:
-codex/implement-user-capsule-upsert-service-1ryqf1
 
       - key: NODE_VERSION
         value: "20.18.0"
       - key: NPM_CONFIG_PRODUCTION
         value: "false"
-codex/implement-user-capsule-upsert-service-1ryqf1
 
       - key: OPENAI_API_KEY
         sync: false
       - key: OPENAI_CAPSULE_MODEL
         sync: false
-odex/implement-user-capsule-upsert-service-1ryqf1
 
       - key: PINECONE_API_KEY
         sync: false
@@ -30,7 +27,6 @@ odex/implement-user-capsule-upsert-service-1ryqf1
         sync: false
       - key: LOG_LEVEL
         value: info
-codex/implement-user-capsule-upsert-service-1ryqf1
 
       - key: PORT
         value: "8080"

--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -2,7 +2,6 @@ import { FastifyPluginAsync } from 'fastify';
 import { z } from 'zod';
 import { AppError, toErrorResponse } from '../utils/errors';
 import { sanitizeOptionalString, sanitizeStringArray, truncateResumeText } from '../utils/sanitize';
-codex/implement-user-capsule-upsert-service-1ryqf1
 
 import { NormalizedUserProfile } from '../utils/types';
 import { generateCapsules } from '../services/capsules';

--- a/src/services/capsules.ts
+++ b/src/services/capsules.ts
@@ -3,7 +3,6 @@ import { NormalizedUserProfile, CapsulePair } from '../utils/types';
 import { joinLanguages, joinWithLineBreak } from '../utils/sanitize';
 import { withRetry } from '../utils/retry';
 import { AppError } from '../utils/errors';
-odex/implement-user-capsule-upsert-service-1ryqf1
 import { getEnv } from '../utils/env';
 import { logger } from '../utils/logger';
 
@@ -109,15 +108,12 @@ export function extractCapsuleTexts(raw: string): CapsulePair {
 export async function generateCapsules(profile: NormalizedUserProfile): Promise<CapsulePair> {
   const prompt = buildCapsulePrompt(profile);
   const client = getOpenAIClient();
-codex/implement-user-capsule-upsert-service-1ryqf1
 
   const capsuleModel = resolveCapsuleModel();
 
   const completion = await withRetry(() =>
     client.chat.completions.create({
       model: capsuleModel,
-codex/implement-user-capsule-upsert-service-1ryqf1
-
       messages: [
         {
           role: 'system',
@@ -153,5 +149,4 @@ codex/implement-user-capsule-upsert-service-1ryqf1
 
   return extractCapsuleTexts(content);
 }
-codex/implement-user-capsule-upsert-service-1ryqf1
 

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -4,14 +4,12 @@ dotenv.config();
 
 export function getEnv(name: string): string | undefined {
   const value = process.env[name];
-codex/implement-user-capsule-upsert-service-1ryqf1
 
   if (typeof value === 'string') {
     const trimmed = value.trim();
     if (trimmed.length > 0) {
       return trimmed;
     }
-codex/implement-user-capsule-upsert-service-1ryqf1
 
   }
   return undefined;

--- a/tests/sanitize.test.ts
+++ b/tests/sanitize.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from 'vitest';
-codex/implement-user-capsule-upsert-service-1ryqf1
 
 import { sanitizeOptionalString, sanitizeStringArray, truncateResumeText } from '../src/utils/sanitize';
 
@@ -8,7 +7,6 @@ describe('sanitize utilities', () => {
     const longText = 'a'.repeat(20_000);
     const truncated = truncateResumeText(longText);
     expect(truncated).toBe(longText);
-codex/implement-user-capsule-upsert-service-1ryqf1
 
   });
 


### PR DESCRIPTION
## Summary
- remove accidental branch marker strings from source files so the TypeScript build succeeds again
- clean the deployment and documentation files and regenerate the lockfile without the stray marker text

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d648c7dc9c8326a7c0392c4fe4f296