### PR TITLE
Handle missing keyword capture during validation

### DIFF
--- a/src/services/validate.ts
+++ b/src/services/validate.ts
@@ -47,7 +47,12 @@ function extractKeywords(taskText: string): string[] {
   if (!match) {
     return [];
   }
-  return match[1]
+  const keywordText = match[1] ?? '';
+  if (keywordText.trim().length === 0) {
+    return [];
+  }
+
+  return keywordText
     .split(',')
     .map((token) => token.trim())
     .filter((token) => token.length > 0);


### PR DESCRIPTION
## Summary
- ensure task capsule validation gracefully handles missing keyword captures
- avoid returning undefined keyword lists when keywords line is empty

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d656db057c832686696ff7cb564b3f