### PR TITLE
Relax job keyword validation to allow partial phrase matches

### DIFF
--- a/docs/bubble-and-deployment.md
+++ b/docs/bubble-and-deployment.md
@@ -12,6 +12,20 @@ The Bubble application stores capsule metadata on the **User** data type using t
 
 Each time Bubble calls `POST /v1/users/upsert`, update these fields with the values returned in the response body. Do **not** persist embedding vectors in Bubble—vectors remain in Pinecone.
 
+## Bubble Job fields
+
+Jobs that operators upsert from Bubble now save the capsule metadata on the **Job** data type using these fields:
+
+| Field name                 | Type | Description |
+| -------------------------- | ---- | ----------- |
+| `capsule_domain_text`      | text | Domain capsule text returned from the job upsert response. |
+| `capsule_domain_vectorID`  | text | Identifier for the Pinecone domain vector returned in the upsert response. |
+| `capsule_task_text`        | text | Task capsule text returned from the job upsert response. |
+| `capsule_task_vectorID`    | text | Identifier for the Pinecone task vector returned in the upsert response. |
+| `capsule_updated_at`       | date | Timestamp copied from the `updated_at` value in the API response. |
+
+Persist only the capsule texts, vector IDs, and timestamp—embedding vectors continue to live exclusively in Pinecone.
+
 ## Render service reference
 
 | Property | Value |

--- a/src/services/job-capsules.ts
+++ b/src/services/job-capsules.ts
@@ -105,26 +105,29 @@ export function normalizeJobRequest(request: UpsertJobRequest): NormalizedJobPos
   const promptText = formatPairsForPrompt(pairs);
   const sourceText = pairs.map(([, value]) => value).join('\n');
 
-  return {
+  const normalized: NormalizedJobPosting = {
     jobId: request.job_id,
-    title,
-    instructions,
-    workloadDesc,
-    datasetDescription,
-    dataSubjectMatter,
-    dataType,
     labelTypes,
-    requirementsAdditional,
     availableLanguages,
     availableCountries,
-    expertiseLevel,
-    timeRequirement,
-    projectType,
-    labelSoftware,
     additionalSkills,
     promptText,
     sourceText,
   };
+
+  if (title !== undefined) normalized.title = title;
+  if (instructions !== undefined) normalized.instructions = instructions;
+  if (workloadDesc !== undefined) normalized.workloadDesc = workloadDesc;
+  if (datasetDescription !== undefined) normalized.datasetDescription = datasetDescription;
+  if (dataSubjectMatter !== undefined) normalized.dataSubjectMatter = dataSubjectMatter;
+  if (dataType !== undefined) normalized.dataType = dataType;
+  if (requirementsAdditional !== undefined) normalized.requirementsAdditional = requirementsAdditional;
+  if (expertiseLevel !== undefined) normalized.expertiseLevel = expertiseLevel;
+  if (timeRequirement !== undefined) normalized.timeRequirement = timeRequirement;
+  if (projectType !== undefined) normalized.projectType = projectType;
+  if (labelSoftware !== undefined) normalized.labelSoftware = labelSoftware;
+
+  return normalized;
 }
 
 async function requestCapsules(

--- a/src/services/job-validate.ts
+++ b/src/services/job-validate.ts
@@ -93,6 +93,125 @@ interface ParsedCapsule {
   keywords: string[];
 }
 
+function normalizeForSearch(input: string): string {
+  return input
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^\p{L}\p{N}\s]+/gu, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function tokenize(text: string): string[] {
+  if (!text) return [];
+  const normalized = normalizeForSearch(text);
+  if (!normalized) return [];
+  return normalized.split(' ');
+}
+
+function buildTokenVariants(token: string): string[] {
+  const variants = new Set<string>([token]);
+
+  if (token.endsWith('ies') && token.length > 3) {
+    variants.add(`${token.slice(0, -3)}y`);
+  }
+
+  if (token.endsWith('es') && token.length > 2) {
+    variants.add(token.slice(0, -2));
+  }
+
+  if (token.endsWith('s') && token.length > 1) {
+    variants.add(token.slice(0, -1));
+  }
+
+  if (token.endsWith('ing') && token.length > 4) {
+    variants.add(token.slice(0, -3));
+    variants.add(`${token.slice(0, -3)}e`);
+  }
+
+  if (token.endsWith('ed') && token.length > 3) {
+    variants.add(token.slice(0, -2));
+    variants.add(token.slice(0, -1));
+  }
+
+  if (token.endsWith('er') && token.length > 3) {
+    variants.add(token.slice(0, -2));
+  }
+
+  if (token.endsWith('ency') && token.length > 4) {
+    variants.add(`${token.slice(0, -3)}t`);
+  }
+
+  if (token.endsWith('ancy') && token.length > 4) {
+    variants.add(`${token.slice(0, -3)}t`);
+  }
+
+  return Array.from(variants);
+}
+
+function levenshteinDistance(a: string, b: string): number {
+  if (a === b) return 0;
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+
+  const matrix: number[][] = Array.from({ length: a.length + 1 }, () => new Array<number>(b.length + 1).fill(0));
+
+  for (let i = 0; i <= a.length; i += 1) {
+    matrix[i]![0] = i;
+  }
+
+  for (let j = 0; j <= b.length; j += 1) {
+    matrix[0]![j] = j;
+  }
+
+  for (let i = 1; i <= a.length; i += 1) {
+    for (let j = 1; j <= b.length; j += 1) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      matrix[i]![j] = Math.min(
+        matrix[i - 1]![j]! + 1,
+        matrix[i]![j - 1]! + 1,
+        matrix[i - 1]![j - 1]! + cost
+      );
+    }
+  }
+
+  return matrix[a.length]![b.length]!;
+}
+
+function tokenMatches(token: string, haystackSet: Set<string>, haystackTokens: string[]): boolean {
+  if (haystackSet.has(token)) {
+    return true;
+  }
+
+  for (const variant of buildTokenVariants(token)) {
+    if (haystackSet.has(variant)) {
+      return true;
+    }
+  }
+
+  if (token.length >= 4) {
+    for (const candidate of haystackTokens) {
+      if (Math.abs(candidate.length - token.length) > 2) continue;
+      if (levenshteinDistance(token, candidate) <= 1) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+function countTokenMatches(tokens: string[], haystackSet: Set<string>, haystackTokens: string[]): number {
+  let matches = 0;
+  for (const token of tokens) {
+    if (tokenMatches(token, haystackSet, haystackTokens)) {
+      matches += 1;
+    }
+  }
+  return matches;
+}
+
 function splitCapsule(capsule: string): ParsedCapsule {
   const trimmed = capsule.trim();
   const match = trimmed.match(/([\s\S]*?)\nKeywords:\s*(.+)$/i);
@@ -149,13 +268,26 @@ function splitCapsule(capsule: string): ParsedCapsule {
 }
 
 function ensureKeywordsAppear(keywords: string[], capsuleText: string, jobSource: string): void {
-  const capsuleLower = capsuleText.toLowerCase();
-  const jobLower = jobSource.toLowerCase();
+  const capsuleTokens = tokenize(capsuleText);
+  const jobTokens = tokenize(jobSource);
+
+  const capsuleTokenSet = new Set(capsuleTokens);
+  const jobTokenSet = new Set(jobTokens);
 
   const missing: string[] = [];
+
   for (const keyword of keywords) {
-    const normalized = keyword.toLowerCase();
-    if (!capsuleLower.includes(normalized) || !jobLower.includes(normalized)) {
+    const keywordTokens = tokenize(keyword);
+    if (keywordTokens.length === 0) {
+      continue;
+    }
+
+    const requiredMatches = keywordTokens.length === 1 ? 1 : Math.max(1, Math.ceil(keywordTokens.length / 2));
+
+    const capsuleMatches = countTokenMatches(keywordTokens, capsuleTokenSet, capsuleTokens);
+    const jobMatches = countTokenMatches(keywordTokens, jobTokenSet, jobTokens);
+
+    if (capsuleMatches < requiredMatches || jobMatches < requiredMatches) {
       missing.push(keyword);
     }
   }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -2,8 +2,13 @@ export type ErrorCode =
   | 'LLM_FAILURE'
   | 'EMBEDDING_FAILURE'
   | 'UPSERT_FAILURE'
+  | 'JOB_UPSERT_FAILURE'
   | 'VALIDATION_ERROR'
-  | 'UNAUTHORIZED';
+  | 'UNAUTHORIZED'
+  | 'MISSING_VECTOR'
+  | 'MATCH_FAILURE'
+  | 'PINECONE_FETCH_FAILURE'
+  | 'PINECONE_QUERY_FAILURE';
 
 export interface ErrorDetails {
   hint?: string;

--- a/tests/job-validate.test.ts
+++ b/tests/job-validate.test.ts
@@ -41,6 +41,24 @@ Keywords: obstetrics, gynecology, prenatal diagnostics, gynecologic oncology, ma
 
     expect(() => validateJobDomainCapsule(capsule, baseJob)).toThrowError(/keywords must appear/i);
   });
+
+  it('allows multi-word keywords when a majority of tokens appear in job text', () => {
+    const capsule = `Expert clinicians in obstetrics and gynecology provide capsule summaries covering maternal-fetal medicine, gynecologic oncology, perinatal genetics, prenatal screening programs, postpartum recovery support, and English fluency expectations for collaborating physicians while fostering clinical collaboration among specialists.
+Keywords: obstetrics, gynecology, maternal-fetal medicine, gynecologic oncology, perinatal genetics, postpartum recovery, English fluency, prenatal screening, clinical collaboration, obstetric specialists`;
+
+    const keywordRichJob: NormalizedJobPosting = {
+      jobId: 'j_keywords',
+      promptText: 'Job text',
+      sourceText:
+        'obstetrics gynecology maternal fetal medicine gynecologic oncology perinatal genetics postpartum recovery prenatal screening clinical collaboration obstetric specialists English communication',
+      labelTypes: [],
+      availableLanguages: [],
+      availableCountries: [],
+      additionalSkills: [],
+    };
+
+    expect(() => validateJobDomainCapsule(capsule, keywordRichJob)).not.toThrow();
+  });
 });
 
 describe('validateJobTaskCapsule', () => {


### PR DESCRIPTION
## Summary
- normalize capsule and job text into comparable tokens before validating keyword overlap
- allow multi-word keywords when at least half of their tokens appear in the job text and add simple stemming/levenshtein fallbacks to reduce false positives
- cover the relaxed behavior with a unit test that exercises multi-word keyword validation

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d722f38bd88326b9a589b6fdd6ef0e