### PR TITLE
Fix Responses helper typing for TypeScript build

### DIFF
--- a/src/services/openai-responses.ts
+++ b/src/services/openai-responses.ts
@@ -1,0 +1,69 @@
+import { ResponseCreateParamsNonStreaming } from 'openai/resources/responses/responses';
+import { getOpenAIClient } from './openai-client';
+
+export type ResponseMessageRole = 'system' | 'user' | 'assistant' | 'developer';
+
+export interface ResponseMessage {
+  role: ResponseMessageRole;
+  content: string;
+}
+
+function supportsCustomTemperature(model: string): boolean {
+  const normalized = model.toLowerCase();
+  if (normalized.includes('reasoning')) {
+    return false;
+  }
+  if (normalized.startsWith('gpt-5')) {
+    return false;
+  }
+  if (normalized.startsWith('gpt-4.1')) {
+    return false;
+  }
+  if (normalized.startsWith('o')) {
+    return false;
+  }
+  return true;
+}
+
+type ResponseInputValue = NonNullable<ResponseCreateParamsNonStreaming['input']>;
+
+function buildResponseInput(messages: ResponseMessage[]): ResponseInputValue {
+  const input = messages.map((message) => ({
+    role: message.role,
+    content: message.content,
+    type: 'message',
+  })) satisfies ResponseInputValue;
+
+  return input;
+}
+
+export interface CreateTextResponseOptions {
+  model: string;
+  messages: ResponseMessage[];
+  temperature?: number;
+  maxOutputTokens?: number;
+}
+
+export async function createTextResponse({
+  model,
+  messages,
+  temperature,
+  maxOutputTokens,
+}: CreateTextResponseOptions): Promise<string> {
+  const client = getOpenAIClient();
+  const params: ResponseCreateParamsNonStreaming = {
+    model,
+    input: buildResponseInput(messages),
+  };
+
+  if (typeof maxOutputTokens === 'number') {
+    params.max_output_tokens = maxOutputTokens;
+  }
+
+  if (typeof temperature === 'number' && supportsCustomTemperature(model)) {
+    params.temperature = temperature;
+  }
+
+  const response = await client.responses.create(params);
+  return response.output_text.trim();
+}

--- a/src/services/validate.ts
+++ b/src/services/validate.ts
@@ -1,7 +1,7 @@
-import { getOpenAIClient } from './openai-client';
 import { resolveCapsuleModel } from './openai-model';
 import { withRetry } from '../utils/retry';
 import { logger } from '../utils/logger';
+import { createTextResponse } from './openai-responses';
 
 const FIXED_SENTENCE =
   'No AI/LLM data-labeling, model training, or evaluation experience was provided in the source.';
@@ -285,11 +285,10 @@ function buildDomainCapsule(body: string): string {
 }
 
 async function rewriteDomainCapsuleSafe(text: string): Promise<string | null> {
-  const client = getOpenAIClient();
   const capsuleModel = resolveCapsuleModel();
   try {
-    const completion = await withRetry(() =>
-      client.chat.completions.create({
+    const rewritten = await withRetry(() =>
+      createTextResponse({
         model: capsuleModel,
         messages: [
           {
@@ -305,7 +304,6 @@ async function rewriteDomainCapsuleSafe(text: string): Promise<string | null> {
         temperature: 0.1,
       })
     );
-    const rewritten = completion.choices?.[0]?.message?.content?.trim();
     return rewritten && rewritten.length > 0 ? rewritten : null;
   } catch (error) {
     logger.warn(

--- a/tests/capsules.test.ts
+++ b/tests/capsules.test.ts
@@ -20,22 +20,14 @@ const mockCreate = vi.fn(async (payload: any) => {
     response.assert(payload);
   }
   return {
-    choices: [
-      {
-        message: {
-          content: response.content,
-        },
-      },
-    ],
+    output_text: response.content,
   };
 });
 
 vi.mock('../src/services/openai-client', () => ({
   getOpenAIClient: () => ({
-    chat: {
-      completions: {
-        create: mockCreate,
-      },
+    responses: {
+      create: mockCreate,
     },
   }),
 }));
@@ -149,7 +141,7 @@ describe('generateCapsules integration', () => {
       mockResponses.push({
         content: `${domainText}\n\n${NO_EVIDENCE_TASK_CAPSULE}`,
         assert: (payload) => {
-          expect(payload.messages[0].content).toBe(CAPSULE_SYSTEM_MESSAGE);
+          expect(payload.input[0].content).toBe(CAPSULE_SYSTEM_MESSAGE);
         },
       });
     }


### PR DESCRIPTION
## Summary
- narrow the Responses helper input builder so it always returns a non-null ResponseInput and satisfies exactOptionalPropertyTypes

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d743befb648326a51504a44d9dd47e