### PR TITLE
Fix Responses API input typing

### DIFF
--- a/src/services/openai-responses.ts
+++ b/src/services/openai-responses.ts
@@ -25,7 +25,9 @@ function supportsCustomTemperature(model: string): boolean {
   return true;
 }
 
-function buildResponseInput(messages: ResponseMessage[]): ResponseCreateParamsNonStreaming['input'] {
+type ResponseInputValue = Exclude<ResponseCreateParamsNonStreaming['input'], undefined>;
+
+function buildResponseInput(messages: ResponseMessage[]): ResponseInputValue {
   return messages.map((message) => ({
     role: message.role,
     content: message.content,


### PR DESCRIPTION
## Summary
- ensure the Responses API input helper returns a non-undefined type that satisfies the SDK typing
- keep createTextResponse building request parameters without tripping exact optional property checks

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d770dda5448326b73327d3604ceef5