### PR TITLE
Refactor job capsule generation to JSON-based prompt

### DIFF
--- a/src/api/jobs.ts
+++ b/src/api/jobs.ts
@@ -124,11 +124,13 @@ export const jobRoutes: FastifyPluginAsync = async (fastify) => {
           vector_id: domainVectorId,
           capsule_text: capsules.domain.text,
           chars: capsules.domain.text.length,
+          keywords: capsules.domain.keywords ?? [],
         },
         task: {
           vector_id: taskVectorId,
           capsule_text: capsules.task.text,
           chars: capsules.task.text.length,
+          keywords: capsules.task.keywords ?? [],
         },
         updated_at: now,
         elapsed_ms: Number(elapsedMs.toFixed(2)),

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -22,6 +22,7 @@ export interface NormalizedUserProfile {
 
 export interface Capsule {
   text: string;
+  keywords?: string[];
 }
 
 export interface CapsulePair {


### PR DESCRIPTION
## Summary
- replace the job capsule prompt with the new JSON-based system/user messages and retry logic, parsing structured capsule text and keywords from the model response
- surface capsule keywords alongside the text so downstream consumers receive both sections in the API response
- extend the shared capsule type to carry optional keyword arrays for job capsules

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d780b536048326ae66ddfe3591d4c3