### PR TITLE
Refine job capsule prompt and filtering

### DIFF
--- a/src/services/openai-responses.ts
+++ b/src/services/openai-responses.ts
@@ -40,6 +40,8 @@ export interface CreateTextResponseOptions {
   messages: ResponseMessage[];
   temperature?: number;
   maxOutputTokens?: number;
+  frequencyPenalty?: number;
+  presencePenalty?: number;
 }
 
 export async function createTextResponse({
@@ -47,6 +49,8 @@ export async function createTextResponse({
   messages,
   temperature,
   maxOutputTokens,
+  frequencyPenalty,
+  presencePenalty,
 }: CreateTextResponseOptions): Promise<string> {
   const client = getOpenAIClient();
   const params: ResponseCreateParamsNonStreaming = {
@@ -60,6 +64,14 @@ export async function createTextResponse({
 
   if (typeof temperature === 'number' && supportsCustomTemperature(model)) {
     params.temperature = temperature;
+  }
+
+  if (typeof frequencyPenalty === 'number') {
+    params.frequency_penalty = frequencyPenalty;
+  }
+
+  if (typeof presencePenalty === 'number') {
+    params.presence_penalty = presencePenalty;
   }
 
   const response = await client.responses.create(params);


### PR DESCRIPTION
## Summary
- replace the capsule generation system and user prompts with the Capsule Tighten v2 instructions, including new decoding parameters
- add capsule text/keyword sanitization to drop disallowed logistics tokens and backfill keywords from remaining high-signal phrases
- pass frequency/presence penalties and max token limits to OpenAI responses helper to support the updated prompt call

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d78a7d35b88326afc24f50b0ef5bb0