### PR TITLE
Fix Render build regression and enforce typecheck pretests

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,11 @@ Copy `.env.example` to `.env` during local development and provide the following
    ```bash
    npm install
    ```
-2. Run the Vitest suite:
+2. Run the Vitest suite (this automatically performs a TypeScript type-check so Render build issues surface locally):
    ```bash
    npm test
    ```
+   > The `pretest` hook runs `npm run typecheck` (a `tsc --noEmit` pass) before executing Vitest. This ensures we catch build time type errors—like the ones Render surfaces—during local development.
 3. Build the production bundle:
    ```bash
    npm run build

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "build": "tsc",
     "start": "node dist/server.js",
     "dev": "tsx watch src/server.ts",
+    "typecheck": "tsc --noEmit",
+    "pretest": "npm run typecheck",
     "test": "vitest run",
     "test:watch": "vitest",
     "index:create": "ts-node scripts/create-index.ts",

--- a/src/services/job-capsules.ts
+++ b/src/services/job-capsules.ts
@@ -9,8 +9,6 @@ const JOB_CAPSULE_SYSTEM_MESSAGE =
   'You produce two concise, high-precision capsules for vector search from a job posting.\nCapsules must be grammatical sentences only (no bullet lists, no angle brackets, no telegraph style).\nUse only facts present in the job text. Do not invent tools, tasks, or domains.\nBe PII-safe: do not include company names or personal names.\nReturn strictly valid JSON; no commentary or extra text outside the JSON.';
 
 const CAPSULE_TEMPERATURE = 0.2;
-const CAPSULE_FREQUENCY_PENALTY = 0.5;
-const CAPSULE_PRESENCE_PENALTY = 0;
 const CAPSULE_MAX_OUTPUT_TOKENS = 800;
 
 const KEYWORD_MIN_COUNT = 10;
@@ -272,8 +270,15 @@ function filterKeywords(
   disallowedSet: Set<string>,
   minCount: number
 ): string[] {
-  if (keywords.length === 1 && keywords[0].trim().toLowerCase() === 'none') {
-    return ['none'];
+  if (keywords.length === 0) {
+    return [];
+  }
+
+  if (keywords.length === 1) {
+    const [firstKeyword] = keywords;
+    if (firstKeyword && firstKeyword.trim().toLowerCase() === 'none') {
+      return ['none'];
+    }
   }
 
   const sanitizedKeywords: string[] = [];
@@ -496,8 +501,6 @@ async function callJobCapsuleModel(userPrompt: string): Promise<string> {
     createTextResponse({
       model: capsuleModel,
       temperature: CAPSULE_TEMPERATURE,
-      frequencyPenalty: CAPSULE_FREQUENCY_PENALTY,
-      presencePenalty: CAPSULE_PRESENCE_PENALTY,
       maxOutputTokens: CAPSULE_MAX_OUTPUT_TOKENS,
       messages: [
         { role: 'system', content: JOB_CAPSULE_SYSTEM_MESSAGE },

--- a/src/services/openai-responses.ts
+++ b/src/services/openai-responses.ts
@@ -40,8 +40,6 @@ export interface CreateTextResponseOptions {
   messages: ResponseMessage[];
   temperature?: number;
   maxOutputTokens?: number;
-  frequencyPenalty?: number;
-  presencePenalty?: number;
 }
 
 export async function createTextResponse({
@@ -49,8 +47,6 @@ export async function createTextResponse({
   messages,
   temperature,
   maxOutputTokens,
-  frequencyPenalty,
-  presencePenalty,
 }: CreateTextResponseOptions): Promise<string> {
   const client = getOpenAIClient();
   const params: ResponseCreateParamsNonStreaming = {
@@ -64,14 +60,6 @@ export async function createTextResponse({
 
   if (typeof temperature === 'number' && supportsCustomTemperature(model)) {
     params.temperature = temperature;
-  }
-
-  if (typeof frequencyPenalty === 'number') {
-    params.frequency_penalty = frequencyPenalty;
-  }
-
-  if (typeof presencePenalty === 'number') {
-    params.presence_penalty = presencePenalty;
   }
 
   const response = await client.responses.create(params);


### PR DESCRIPTION
## Summary
- fix the job capsule keyword sanitizer to handle optional tokens safely and use supported response options
- drop unsupported frequency/presence penalties when calling the OpenAI Responses API so `tsc` succeeds again
- add a reusable `npm run typecheck` script hooked into `npm test` and document the workflow to catch build issues locally

## Testing
- npm run typecheck
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d78df64a588326af71e20f4ee8f8f9