### PR TITLE
Add coverage for constrained OpenAI parameter handling

### DIFF
--- a/src/services/openai-responses.ts
+++ b/src/services/openai-responses.ts
@@ -12,21 +12,29 @@ export interface ResponseMessage {
   content: string;
 }
 
-function supportsCustomTemperature(model: string): boolean {
+function isConstrainedModel(model: string): boolean {
   const normalized = model.toLowerCase();
   if (normalized.includes('reasoning')) {
-    return false;
+    return true;
   }
   if (normalized.startsWith('gpt-5')) {
-    return false;
+    return true;
   }
   if (normalized.startsWith('gpt-4.1')) {
-    return false;
+    return true;
   }
   if (normalized.startsWith('o')) {
-    return false;
+    return true;
   }
-  return true;
+  return false;
+}
+
+function supportsCustomTemperature(model: string): boolean {
+  return !isConstrainedModel(model);
+}
+
+function supportsCustomMaxOutputTokens(model: string): boolean {
+  return !isConstrainedModel(model);
 }
 
 type ResponseInputValue = Exclude<ResponseCreateParamsNonStreaming['input'], undefined>;
@@ -58,7 +66,7 @@ export async function createTextResponse({
     input: buildResponseInput(messages),
   };
 
-  if (typeof maxOutputTokens === 'number') {
+  if (typeof maxOutputTokens === 'number' && supportsCustomMaxOutputTokens(model)) {
     params.max_output_tokens = maxOutputTokens;
   }
 

--- a/tests/openai-responses.test.ts
+++ b/tests/openai-responses.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTextResponse } from '../src/services/openai-responses';
+
+const mockCreate = vi.fn();
+
+vi.mock('../src/services/openai-client', () => ({
+  getOpenAIClient: () => ({
+    responses: {
+      create: mockCreate,
+    },
+  }),
+}));
+
+describe('createTextResponse parameter handling', () => {
+  beforeEach(() => {
+    mockCreate.mockReset();
+  });
+
+  it('applies caller-provided tuning for unconstrained models', async () => {
+    mockCreate.mockResolvedValue({
+      output_text: 'hello world',
+    });
+
+    const result = await createTextResponse({
+      model: 'gpt-4o-mini',
+      messages: [
+        { role: 'system', content: 'You are a test harness.' },
+        { role: 'user', content: 'Say hello.' },
+      ],
+      temperature: 0.2,
+      maxOutputTokens: 512,
+    });
+
+    expect(result).toBe('hello world');
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    const payload = mockCreate.mock.calls[0][0];
+    expect(payload.temperature).toBe(0.2);
+    expect(payload.max_output_tokens).toBe(512);
+  });
+
+  it('omits tuning parameters for constrained reasoning-style models', async () => {
+    mockCreate.mockResolvedValue({
+      output_text: 'constraints respected',
+    });
+
+    await createTextResponse({
+      model: 'o1-mini',
+      messages: [
+        { role: 'system', content: 'You are a test harness.' },
+        { role: 'user', content: 'Say hello.' },
+      ],
+      temperature: 0.7,
+      maxOutputTokens: 2048,
+    });
+
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    const payload = mockCreate.mock.calls[0][0];
+    expect(payload.temperature).toBeUndefined();
+    expect(payload.max_output_tokens).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests verifying createTextResponse preserves caller overrides for standard models
- ensure constrained o-series models skip custom temperature and max token parameters

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d794ce5c908326bfb1b456aafadeb5